### PR TITLE
Added optional synapses configuration parameter verbose-logging

### DIFF
--- a/resources/config.yml
+++ b/resources/config.yml
@@ -7,4 +7,5 @@ synapses:
 #   is-main-server: true
 #   server-password: 32bitlongkey
 #   description: "A Synapse client"
+#   verbose-logging: false
 loadingScreen: true

--- a/src/synapse/Synapse.php
+++ b/src/synapse/Synapse.php
@@ -67,6 +67,7 @@ class Synapse{
 		]
 	 */
 	private $description;
+	private $verboseLogging;
 	private $connectionTime = PHP_INT_MAX;
 
 	public function __construct(Server $server, array $config){
@@ -76,6 +77,7 @@ class Synapse{
 		$this->isMainServer = $config["is-main-server"] ?? true;
 		$this->password = $config["server-password"];
 		$this->description = $config["description"];
+		$this->verboseLogging = $config["verbose-logging"] ?? false;
 		$this->logger = $server->getLogger();
 		$this->interface = new SynapseInterface($this, $this->serverIp, $this->port);
 		$this->synLibInterface = new SynLibInterface($this, $this->interface);
@@ -201,7 +203,7 @@ class Synapse{
 	}
 
 	public function handleDataPacket(DataPacket $pk){
-		$this->logger->debug("Received packet " . $pk::NETWORK_ID . " from {$this->serverIp}:{$this->port}");
+		if ($this->verboseLogging) $this->logger->debug("Received packet " . $pk::NETWORK_ID . " from {$this->serverIp}:{$this->port}");
 		switch($pk::NETWORK_ID){
 			case Info::DISCONNECT_PACKET:
 				/** @var DisconnectPacket $pk */


### PR DESCRIPTION
Debug logging in handleDataPacket was a bit too verbose by default so added optional parameter verbose-logging to synapses config.  Defaults to false if not specified.