### PR TITLE
Fixes commands not working after server change

### DIFF
--- a/src/synapse/Player.php
+++ b/src/synapse/Player.php
@@ -90,7 +90,7 @@ class Player extends PMPlayer{
 				$this->close($this->getLeaveMessage(), "Server is white-listed");
 
 				return;
-			}elseif($this->server->getNameBans()->isBanned(strtolower($this->getName())) or $this->server->getIPBans()->isBanned($this->getAddress()) or $this->server->getName() != "PocketMine-MP" && $this->server->getCIDBans()->isBanned($this->randomClientId)){
+			}elseif($this->server->getNameBans()->isBanned(strtolower($this->getName())) or $this->server->getIPBans()->isBanned($this->getAddress()) or method_exists($this->server, "getCIDBans") && $this->server->getCIDBans()->isBanned($this->randomClientId)){
 				$this->close($this->getLeaveMessage(), TextFormat::RED . "You are banned");
 
 				return;

--- a/src/synapse/Player.php
+++ b/src/synapse/Player.php
@@ -263,7 +263,8 @@ class Player extends PMPlayer{
 			$this->dataPacket($pk);
 
 			$this->forceMovement = $this->teleportPosition = $this->getPosition();
-		}
+			$this->sendCommandData();		
+               }
 	}
 	
 	public function doFirstSpawn()


### PR DESCRIPTION
Fixes the issue where when a client switches to a different server they cannot use commands from the new server. Fixes by sending the client the new command map data on join of new server.

Fixes #31 